### PR TITLE
More BIG-IP functionality and iWorkflow support

### DIFF
--- a/lib/iControl.js
+++ b/lib/iControl.js
@@ -69,7 +69,7 @@ iControl.prototype.delete = function(path, cb) {
 // Execute request
 iControl.prototype._request = function(opts, cb) {
   if (typeof opts.path !== 'string') return cb('URL must be specified', null);
-  this.url = '/mgmt/tm' + opts.path;
+  this.url = '/mgmt' + opts.path;
   this.uri = this.proto + '://' + this.host + ':' + this.port + this.url;
   this.method = opts.method;
 


### PR DESCRIPTION
Changing the base URI context will open up support for more BIG-IP modules and will also enable support for F5 iWorkflow.
/mgmt/tm   <- this is for LTM only functionality.
/mgmt    <- this is for F5 iControl REST support.

Alternatively, we can rename this project to "LTM-iControl" and then I/you can create a new iControl project with the correct base URI that warrants the name "iControl.js".

This does mean you would need to edit any scripts using iControl.js to start from a new context: "/tm/ltm" instead of "/ltm". 
