### PR TITLE
Use PATCH instead of PUT for modify.

### DIFF
--- a/lib/iControl.js
+++ b/lib/iControl.js
@@ -56,7 +56,7 @@ iControl.prototype.create = function(path, body, cb) {
 
 // Modify
 iControl.prototype.modify = function(path, body, cb) {
-  var opts = { path: path, body: body, method: 'PUT' };
+  var opts = { path: path, body: body, method: 'PATCH' };
   this._request(opts, cb);
 };
 
@@ -112,7 +112,7 @@ iControl.prototype._request = function(opts, cb) {
 
       return cb(msg, false);
     }
-    
+
     // If retrieving via GET, handle pagination
     if (this.method === 'GET') {
 
@@ -126,7 +126,7 @@ iControl.prototype._request = function(opts, cb) {
         return cb(false, body);
       }
     }
-    
+
     // For POST/PUT/DELETE, return body
     else {
       return cb(false, body);


### PR DESCRIPTION
While it is arguable more proper in REST to have modify do a PUT,
in tmsh, and therefore iControl REST, modify is a PATCH.

For example, do a tmsh modify sys global-settings: only what you set is
modified. But do a PUT to /mgmt/tm/sys/global-settings and items you don't
set (mgmtDhcp, for example) will be set.
