### PR TITLE
Specify headers

### DIFF
--- a/lib/iControl.js
+++ b/lib/iControl.js
@@ -24,45 +24,72 @@ var iControl = function(opts) {
 iControl.prototype.list = function(path, opts, cb) {
 
   // No options have been specified
-  if (arguments.length === 2) {
+  if (typeof opts === 'function') {
     cb = opts;
     opts = {};
   }
+  opts = opts || {};
 
-  // Options have been specified
-  else {
+  // Parse options
+  // TODO: support other options
+  var queryComponents = [];
+  if (opts.expandAll)    queryComponents.push('$expand=*');
+  if (opts.includeStats) queryComponents.push('$stats=true');
 
-    // Parse options
-    // TODO: support other options
-    var queryComponents = [];
-    if (opts.expandAll)    queryComponents.push('$expand=*');
-    if (opts.includeStats) queryComponents.push('$stats=true');
-
-    // Build query string
-    if (queryComponents.length !== 0) {
-      opts.query = '?' + queryComponents.join('&');
-    }
+  // Build query string
+  if (queryComponents.length !== 0) {
+    opts.query = '?' + queryComponents.join('&');
   }
+
   opts.path = path;
   opts.method = 'GET';
   this._request(opts, cb);
 };
 
 // Create
-iControl.prototype.create = function(path, body, cb) {
-  var opts = { path: path, body: body, method: 'POST' };
+iControl.prototype.create = function(path, body, opts, cb) {
+  // No options have been specified
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = {};
+  }
+  opts = opts || {};
+
+  opts.path = path;
+  opts.body = body;
+  opts.method = 'POST';
+
   this._request(opts, cb);
 };
 
 // Modify
-iControl.prototype.modify = function(path, body, cb) {
-  var opts = { path: path, body: body, method: 'PUT' };
+iControl.prototype.modify = function(path, body, opts, cb) {
+  // No options have been specified
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = {};
+  }
+  opts = opts || {};
+
+  opts.path = path;
+  opts.body = body;
+  opts.method = 'PUT';
+
   this._request(opts, cb);
 };
 
 // Delete
-iControl.prototype.delete = function(path, cb) {
-  var opts = { path: path, method: 'DELETE' };
+iControl.prototype.delete = function(path, opts, cb) {
+  // No options have been specified
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = {};
+  }
+  opts = opts || {};
+
+  opts.path = path;
+  opts.method = 'DELETE';
+
   this._request(opts, cb);
 };
 
@@ -92,6 +119,9 @@ iControl.prototype._request = function(opts, cb) {
   // If query string has been specified, add to request options
   if (typeof opts.query === 'string') this.requestOpts.qs = opts.query;
 
+  // If headers have been specified, add to request options
+  if (typeof opts.headers === 'object') this.requestOpts.headers = opts.headers;
+
   // Do request
   request(this.requestOpts, function(err, res, body) {
 
@@ -112,7 +142,7 @@ iControl.prototype._request = function(opts, cb) {
 
       return cb(msg, false);
     }
-    
+
     // If retrieving via GET, handle pagination
     if (this.method === 'GET') {
 
@@ -126,7 +156,7 @@ iControl.prototype._request = function(opts, cb) {
         return cb(false, body);
       }
     }
-    
+
     // For POST/PUT/DELETE, return body
     else {
       return cb(false, body);

--- a/lib/iControl.js
+++ b/lib/iControl.js
@@ -120,7 +120,20 @@ iControl.prototype._request = function(opts, cb) {
   if (typeof opts.query === 'string') this.requestOpts.qs = opts.query;
 
   // If headers have been specified, add to request options
-  if (typeof opts.headers === 'object') this.requestOpts.headers = opts.headers;
+  if (typeof opts.headers === 'object') {
+    var headers;
+    this.requestOpts.headers = opts.headers;
+
+    // If we are specifying the content-type and it's not json, don't
+    // set json as a request option
+    // TODO: figure out if it is specified as applicaiton/json...
+    headers = Object.keys(opts.headers).map(function(header) {
+      return header.toLowerCase();
+    });
+    if (headers.indexOf('content-type') > 0) {
+      this.requestOpts.json = false;
+    }
+  }
 
   // Do request
   request(this.requestOpts, function(err, res, body) {

--- a/lib/iControl.js
+++ b/lib/iControl.js
@@ -130,7 +130,7 @@ iControl.prototype._request = function(opts, cb) {
     for (header in opts.headers) {
       if (opts.headers.hasOwnProperty(header)) {
         if (header.toLowerCase() === 'content-type') {
-          if (opts.headers[header] !== 'application.json') {
+          if (opts.headers[header] !== 'application/json') {
             this.requestOpts.json = false;
           }
         }

--- a/lib/iControl.js
+++ b/lib/iControl.js
@@ -114,7 +114,7 @@ iControl.prototype._request = function(opts, cb) {
   };
 
   // If body has been specified, add to request options
-  if (typeof opts.body === 'object') this.requestOpts.body = opts.body;
+  if (typeof opts.body === 'object' || typeof opts.body === 'string') this.requestOpts.body = opts.body;
 
   // If query string has been specified, add to request options
   if (typeof opts.query === 'string') this.requestOpts.qs = opts.query;

--- a/lib/iControl.js
+++ b/lib/iControl.js
@@ -95,6 +95,8 @@ iControl.prototype.delete = function(path, opts, cb) {
 
 // Execute request
 iControl.prototype._request = function(opts, cb) {
+  var header;
+
   if (typeof opts.path !== 'string') return cb('URL must be specified', null);
   this.url = '/mgmt/tm' + opts.path;
   this.uri = this.proto + '://' + this.host + ':' + this.port + this.url;
@@ -121,17 +123,18 @@ iControl.prototype._request = function(opts, cb) {
 
   // If headers have been specified, add to request options
   if (typeof opts.headers === 'object') {
-    var headers;
     this.requestOpts.headers = opts.headers;
 
     // If we are specifying the content-type and it's not json, don't
     // set json as a request option
-    // TODO: figure out if it is specified as applicaiton/json...
-    headers = Object.keys(opts.headers).map(function(header) {
-      return header.toLowerCase();
-    });
-    if (headers.indexOf('content-type') > 0) {
-      this.requestOpts.json = false;
+    for (header in opts.headers) {
+      if (opts.headers.hasOwnProperty(header)) {
+        if (header.toLowerCase() === 'content-type') {
+          if (opts.headers[header] !== 'application.json') {
+            this.requestOpts.json = false;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Two separate but related changes:
- Allow non-json bodies.
- Allow arbitrary headers.

Use cases are:
- Allow for commands to be issued in a transaction. This requires setting the X-F5-REST-Coordination-Id header
- Allow calling the file uploader. This requires setting the Content-Range header and using a non-json body.

Note that this does not include pull request #4 so if these are both accepted, some manual merging is likely required.
